### PR TITLE
[BC] Add support for nested options

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -39,34 +39,34 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('keys')
                     ->info('<info>Customize available keys</info>')
                     ->addDefaultsIfNotSet()
-                    ->children()
-                        ->append(
-                            $this->addKeysConfig(
-                                'form',
-                                array(
-                                    'label' => "label",
-                                    'help'  => "help",
-                                )
+                ->children()
+                    ->append(
+                        $this->addKeysConfig(
+                            'form',
+                            array(
+                                '[label]' => "label",
+                                '[help]'  => "help",
                             )
                         )
-                        ->append(
-                            $this->addKeysConfig(
-                                'collection',
-                                array(
-                                    'label_add'    => "label_add",
-                                    'label_delete' => "label_delete",
-                                )
+                    )
+                    ->append(
+                        $this->addKeysConfig(
+                            'collection',
+                            array(
+                                '[label_add]'    => "label_add",
+                                '[label_delete]' => "label_delete",
                             )
                         )
-                        ->append(
-                            $this->addKeysConfig(
-                                'choice',
-                                array(
-                                    'empty_value' => "empty_value",
-                                )
+                    )
+                    ->append(
+                        $this->addKeysConfig(
+                            'choice',
+                            array(
+                                '[empty_value]' => "empty_value",
                             )
                         )
-                    ->end()
+                    )
+                ->end()
                 ->end()
                 ->arrayNode('blocks')
                     ->info('<info>Customize the ways keys are built</info>')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -39,34 +39,34 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('keys')
                     ->info('<info>Customize available keys</info>')
                     ->addDefaultsIfNotSet()
-                ->children()
-                    ->append(
-                        $this->addKeysConfig(
-                            'form',
-                            array(
-                                '[label]' => "label",
-                                '[help]'  => "help",
+                    ->children()
+                        ->append(
+                            $this->addKeysConfig(
+                                'form',
+                                array(
+                                    '[label]' => "label",
+                                    '[help]'  => "help",
+                                )
                             )
                         )
-                    )
-                    ->append(
-                        $this->addKeysConfig(
-                            'collection',
-                            array(
-                                '[label_add]'    => "label_add",
-                                '[label_delete]' => "label_delete",
+                        ->append(
+                            $this->addKeysConfig(
+                                'collection',
+                                array(
+                                    '[label_add]'    => "label_add",
+                                    '[label_delete]' => "label_delete",
+                                )
                             )
                         )
-                    )
-                    ->append(
-                        $this->addKeysConfig(
-                            'choice',
-                            array(
-                                '[empty_value]' => "empty_value",
+                        ->append(
+                            $this->addKeysConfig(
+                                'choice',
+                                array(
+                                    '[empty_value]' => "empty_value",
+                                )
                             )
                         )
-                    )
-                ->end()
+                    ->end()
                 ->end()
                 ->arrayNode('blocks')
                     ->info('<info>Customize the ways keys are built</info>')

--- a/Form/Extension/TreeAwareExtension.php
+++ b/Form/Extension/TreeAwareExtension.php
@@ -15,6 +15,8 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Elao\Bundle\FormTranslationBundle\Builders\FormTreebuilder;
 use Elao\Bundle\FormTranslationBundle\Builders\FormKeybuilder;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
  * Tree Aware Extension
@@ -48,6 +50,21 @@ abstract class TreeAwareExtension extends AbstractTypeExtension
      * @var boolean
      */
     protected $autoGenerate = false;
+
+    /**
+     * PropertyAccessor
+     *
+     * @var PropertyAccessorInterface
+     */
+    protected $propertyAccessor;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
+    }
 
     /**
      * Enable or disable automatic generation of missing labels
@@ -96,7 +113,7 @@ abstract class TreeAwareExtension extends AbstractTypeExtension
     {
         if ($this->treeBuilder && $this->keyBuilder) {
             foreach ($this->keys as $key => $value) {
-                if (isset($options[$key]) && $options[$key] === true) {
+                if ($this->propertyAccessor->isReadable($options, $key) && $this->propertyAccessor->getValue($options, $key) === true) {
                     $this->generateKey($view, $key, $value);
                 }
             }
@@ -116,6 +133,6 @@ abstract class TreeAwareExtension extends AbstractTypeExtension
             $view->vars['tree'] = $this->treeBuilder->getTree($view);
         }
 
-        $view->vars[$key] = $this->keyBuilder->buildKeyFromTree($view->vars['tree'], $value);
+        $this->propertyAccessor->setValue($view->vars, $key, $this->keyBuilder->buildKeyFromTree($view->vars['tree'], $value));
     }
 }

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Add ElaoFormTranslationBundle to your composer.json:
 ``` json
 {
     "require": {
-        "elao/form-translation-bundle": "1.0.*"
+        "elao/form-translation-bundle": "2.0.*"
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -177,12 +177,12 @@ elao_form_translation:
     # Customize available keys
     keys:
         form:
-            label:  "label"
-            help:   "help"
+            '[label]':  "label"
+            '[help]':   "help"
             # Add yours ...
         collection:
-            label_add:      "label_add"
-            label_delete:   "label_delete"
+            '[label_add]':      "label_add"
+            '[label_delete]':   "label_delete"
             # Add yours ...
 
     # Customize the ways keys are built

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "symfony/framework-bundle": "~2.3",
-        "symfony/form": "~2.3"
+        "symfony/form": "~2.3",
+        "symfony/property-access": "~2.3"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
This allows to generate translation labels for nested options like those used by MopaBoostrapBundle.


Example for [widget add ons](https://github.com/phiamo/MopaBootstrapBundle/blob/master/Resources/doc/3-form-extension-templates.md#widget-addons):
```php
$builder->add(
    'foo',
    'text',
    [
        'widget_addon_prepend' => [
            'text' => true
        ],
    ]
);
```