### PR TITLE
Add support for nested options

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -114,6 +114,7 @@ class Configuration implements ConfigurationInterface
             ->prototype('scalar')
                 ->isRequired()
             ->end()
+	    ->normalizeKeys(false)
             ->defaultValue($default);
 
         return $node;

--- a/Tests/Builders/FormKeyBuilderTest.php
+++ b/Tests/Builders/FormKeyBuilderTest.php
@@ -27,8 +27,10 @@ class FormKeyBuilderTest extends FormTranslationTestCase
         $view  = $form->createView();
         $tree  = $treeBuilder->getTree($view['bar']);
         $label = $keyBuilder->buildKeyFromTree($tree, 'label');
+	$attr = $keyBuilder->buildKeyFromTree($tree, 'attr.baz');
 
         $this->assertEquals('form.foo.children.bar.label', $label);
+	$this->assertEquals('form.foo.children.bar.attr.baz', $attr);
     }
 
     /**
@@ -56,8 +58,12 @@ class FormKeyBuilderTest extends FormTranslationTestCase
         $prototypeTree  = $treeBuilder->getTree($view['bar']->vars['prototype']);
         $barLabel       = $keyBuilder->buildKeyFromTree($barTree, 'label');
         $prototypeLabel = $keyBuilder->buildKeyFromTree($prototypeTree, 'label');
+	$barAttr        = $keyBuilder->buildKeyFromTree($barTree, 'attr.baz');
+	$prototypeAttr  = $keyBuilder->buildKeyFromTree($prototypeTree, 'attr.baz');
 
         $this->assertEquals('form.foo.children.bar.label', $barLabel);
+	$this->assertEquals('form.foo.children.bar.attr.baz', $barAttr);
         $this->assertEquals('form.foo.children.bar.prototype.label', $prototypeLabel);
+	$this->assertEquals('form.foo.children.bar.prototype.attr.baz', $prototypeAttr);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "symfony/framework-bundle": "~2.8|~3.0|~4.0",
-        "symfony/form": "~2.8|~3.0|~4.0"
+        "symfony/form": "~2.8|~3.0|~4.0",
+        "symfony/property-access": "~2.8|~3.0|~4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0"


### PR DESCRIPTION
This allows to generate translation labels for nested options like those used by MopaBoostrapBundle.

Example for widget add ons:

``` php
$builder->add(
    'foo',
    'text',
    [
        'widget_addon_prepend' => [
            'text' => true
        ],
    ]
);
```

If this gets merged I propose putting it into a new branch (2.0 or something) because of the backwards compatibility breaking change this introduces.
