### PR TITLE
Added JMS translation extractor

### DIFF
--- a/DependencyInjection/Compiler/JMSTranslationPass.php
+++ b/DependencyInjection/Compiler/JMSTranslationPass.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Elao\Bundle\FormTranslationBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class JMSTranslationPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasExtension('jms_translation')) {
+            $container->removeDefinition('elao.form_translation.extractor.form_extractor');
+        }
+    }
+}

--- a/ElaoFormTranslationBundle.php
+++ b/ElaoFormTranslationBundle.php
@@ -10,6 +10,8 @@
 
 namespace Elao\Bundle\FormTranslationBundle;
 
+use Elao\Bundle\FormTranslationBundle\DependencyInjection\Compiler\JMSTranslationPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -17,4 +19,11 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class ElaoFormTranslationBundle extends Bundle
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new JMSTranslationPass());
+    }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -14,7 +14,6 @@
         <service id="elao.form_translation.tree_builder" class="%elao.form_translation.tree_builder.class%" />
         <service id="elao.form_translation.key_builder" class="%elao.form_translation.key_builder.class%" />
         <service id="elao.form_translation.extractor.form_extractor" class="%elao.form_translation.extractor.form_extractor.class%" public="false">
-            <argument type="service" id="jms_translation.doc_parser" />
             <argument type="service" id="form.factory" />
             <argument type="service" id="logger" />
             <tag name="jms_translation.file_visitor" />

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,10 +7,20 @@
     <parameters>
         <parameter key="elao.form_translation.tree_builder.class">Elao\Bundle\FormTranslationBundle\Builders\FormTreeBuilder</parameter>
         <parameter key="elao.form_translation.key_builder.class">Elao\Bundle\FormTranslationBundle\Builders\FormKeyBuilder</parameter>
+        <parameter key="elao.form_translation.extractor.form_extractor.class">Elao\Bundle\FormTranslationBundle\Translation\Extractor\FormExtractor</parameter>
     </parameters>
 
     <services>
         <service id="elao.form_translation.tree_builder" class="%elao.form_translation.tree_builder.class%" />
         <service id="elao.form_translation.key_builder" class="%elao.form_translation.key_builder.class%" />
+        <service id="elao.form_translation.extractor.form_extractor" class="%elao.form_translation.extractor.form_extractor.class%" public="false">
+            <argument type="service" id="jms_translation.doc_parser" />
+            <argument type="service" id="form.factory" />
+            <argument type="service" id="logger" />
+            <tag name="jms_translation.file_visitor" />
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+        </service>
     </services>
 </container>

--- a/Tests/Fixtures/Form/Type/AdvancedType.php
+++ b/Tests/Fixtures/Form/Type/AdvancedType.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Elao\Bundle\FormTranslationBundle\Tests\Fixtures\Form\Type;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class AdvancedType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('name')
+            ->add('phone')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setRequired('dt')
+            ->setAllowedTypes('dt', \DateTime::class)
+        ;
+    }
+
+    /**
+     * @param ContainerInterface $container
+     *
+     * @return array
+     */
+    public static function extractorOptions(ContainerInterface $container)
+    {
+        return [
+            'dt' => new \DateTime(),
+        ];
+    }
+}

--- a/Tests/Fixtures/Form/Type/SimpleType.php
+++ b/Tests/Fixtures/Form/Type/SimpleType.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Elao\Bundle\FormTranslationBundle\Tests\Fixtures\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class SimpleType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('name')
+            ->add('phone')
+        ;
+    }
+}

--- a/Tests/Translation/Extractor/FormExtractorTest.php
+++ b/Tests/Translation/Extractor/FormExtractorTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Elao\Bundle\FormTranslationBundle\Tests\Translation\Extractor;
+
+use Elao\Bundle\FormTranslationBundle\Builders\FormKeyBuilder;
+use Elao\Bundle\FormTranslationBundle\Builders\FormTreeBuilder;
+use Elao\Bundle\FormTranslationBundle\DependencyInjection\Configuration;
+use Elao\Bundle\FormTranslationBundle\Form\Extension;
+use Elao\Bundle\FormTranslationBundle\Test\FormTranslationTestCase;
+use Elao\Bundle\FormTranslationBundle\Tests\Fixtures\Form\Type\AdvancedType;
+use Elao\Bundle\FormTranslationBundle\Tests\Fixtures\Form\Type\SimpleType;
+use Elao\Bundle\FormTranslationBundle\Translation\Extractor\FormExtractor;
+use JMS\TranslationBundle\Model\MessageCatalogue;
+use PhpParser\Lexer\Emulative;
+use PhpParser\Parser;
+use Psr\Log\NullLogger;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\DependencyInjection\Container;
+
+class FormExtractorTest extends FormTranslationTestCase
+{
+    /**
+     * Get Form Type Extensions
+     *
+     * @return array
+     */
+    protected function getTypeExtensions()
+    {
+        $processor = new Processor();
+        $configuration = new Configuration();
+        $config = $processor->processConfiguration($configuration, []);
+
+        $ext = [];
+
+        /** @var Extension\TreeAwareExtension $type */
+        foreach (parent::getTypeExtensions() as $type) {
+            $type->setAutoGenerate(true);
+            $type->setKeybuilder(new FormKeyBuilder());
+            $type->setTreebuilder(new FormTreeBuilder());
+            $type->setKeys($config['keys']['form']);
+
+            $ext[] = $type;
+        }
+
+        return $ext;
+    }
+
+    public function testSimpleFormExtract()
+    {
+        $extractor = new FormExtractor($this->factory, new NullLogger());
+
+        $file = new \SplFileInfo((new \ReflectionClass(SimpleType::class))->getFileName());
+        $catalogue = new MessageCatalogue();
+        $parser = $parser = new Parser(new Emulative);
+
+        $extractor->visitPhpFile(
+            $file,
+            $catalogue,
+            $parser->parse(file_get_contents($file->getPathname()))
+        );
+
+        $this->assertEquals('form.simple.children.name.label', $catalogue->get('form.simple.children.name.label'));
+        $this->assertEquals('form.simple.children.phone.label', $catalogue->get('form.simple.children.phone.label'));
+    }
+
+    public function testAdvancedFormExtract()
+    {
+        $extractor = new FormExtractor($this->factory, new NullLogger());
+        $extractor->setContainer(new Container());
+
+        $file = new \SplFileInfo((new \ReflectionClass(AdvancedType::class))->getFileName());
+        $catalogue = new MessageCatalogue();
+        $parser = $parser = new Parser(new Emulative);
+
+        $extractor->visitPhpFile(
+            $file,
+            $catalogue,
+            $parser->parse(file_get_contents($file->getPathname()))
+        );
+
+        $this->assertEquals('form.advanced.children.name.label', $catalogue->get('form.advanced.children.name.label'));
+        $this->assertEquals('form.advanced.children.phone.label', $catalogue->get('form.advanced.children.phone.label'));
+    }
+}

--- a/Translation/Extractor/FormExtractor.php
+++ b/Translation/Extractor/FormExtractor.php
@@ -159,7 +159,12 @@ class FormExtractor implements FileVisitorInterface, NodeVisitor, ContainerAware
         $labels = [];
 
         foreach ($view as $field) {
-            if (count($field) > 0) {
+            if (count($field)
+                && (
+                    !isset($field->vars['choice_translation_domain'])
+                    || $field->vars['choice_translation_domain'] !== false
+                )
+            ) {
                 $labels += $this->extractView($field);
             }
 

--- a/Translation/Extractor/FormExtractor.php
+++ b/Translation/Extractor/FormExtractor.php
@@ -2,7 +2,6 @@
 
 namespace Elao\Bundle\FormTranslationBundle\Translation\Extractor;
 
-use Doctrine\Common\Annotations\DocParser;
 use JMS\TranslationBundle\Model\FileSource;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
@@ -54,20 +53,15 @@ class FormExtractor implements FileVisitorInterface, NodeVisitor, ContainerAware
     protected $container;
 
     /**
-     * @param DocParser            $docParser
      * @param FormFactoryInterface $formFactory
      * @param LoggerInterface      $logger
      */
-    public function __construct(
-        DocParser $docParser,
-        FormFactoryInterface $formFactory,
-        LoggerInterface $logger
-    ) {
+    public function __construct(FormFactoryInterface $formFactory, LoggerInterface $logger)
+    {
         $this->traverser = new NodeTraverser();
         $this->traverser->addVisitor(new NameResolver());
         $this->traverser->addVisitor($this);
 
-        $this->docParser = $docParser;
         $this->formFactory = $formFactory;
         $this->logger = $logger;
     }

--- a/Translation/Extractor/FormExtractor.php
+++ b/Translation/Extractor/FormExtractor.php
@@ -165,7 +165,7 @@ class FormExtractor implements FileVisitorInterface, NodeVisitor, ContainerAware
                     || $field->vars['choice_translation_domain'] !== false
                 )
             ) {
-                $labels += $this->extractView($field);
+                $labels = array_merge($labels, $this->extractView($field));
             }
 
             $labels[] = $field->vars['label'];

--- a/Translation/Extractor/FormExtractor.php
+++ b/Translation/Extractor/FormExtractor.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Elao\Bundle\FormTranslationBundle\Translation\Extractor;
+
+use Doctrine\Common\Annotations\DocParser;
+use JMS\TranslationBundle\Model\FileSource;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Model\MessageCatalogue;
+use JMS\TranslationBundle\Model\SourceInterface;
+use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeTraverserInterface;
+use PhpParser\NodeVisitor;
+use PhpParser\NodeVisitor\NameResolver;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormTypeInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Exception\ExceptionInterface;
+
+class FormExtractor implements FileVisitorInterface, NodeVisitor, ContainerAwareInterface
+{
+    /**
+     * @var \SplFileInfo
+     */
+    protected $file;
+
+    /**
+     * @var MessageCatalogue
+     */
+    protected $catalogue;
+
+    /**
+     * @var NodeTraverserInterface
+     */
+    protected $traverser;
+
+    /**
+     * @var FormFactoryInterface
+     */
+    protected $formFactory;
+
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @param DocParser            $docParser
+     * @param FormFactoryInterface $formFactory
+     * @param LoggerInterface      $logger
+     */
+    public function __construct(
+        DocParser $docParser,
+        FormFactoryInterface $formFactory,
+        LoggerInterface $logger
+    ) {
+        $this->traverser = new NodeTraverser();
+        $this->traverser->addVisitor(new NameResolver());
+        $this->traverser->addVisitor($this);
+
+        $this->docParser = $docParser;
+        $this->formFactory = $formFactory;
+        $this->logger = $logger;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    function visitPhpFile(\SplFileInfo $file, MessageCatalogue $catalogue, array $ast)
+    {
+        $this->file = $file;
+        $this->catalogue = $catalogue;
+        $this->traverser->traverse($ast);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function enterNode(Node $node)
+    {
+        if ($node instanceof Node\Stmt\Class_) {
+            $fqcn = (string) $node->namespacedName;
+
+            require_once $this->file->getPathname();
+
+            $refl = new \ReflectionClass($fqcn);
+
+            if ($refl->implementsInterface(FormTypeInterface::class)) {
+                // Drilling down with the node visitor is not the way to go here, extends, traits etc.
+
+                if ($refl->hasMethod('extractorOptions')) {
+                    $method = $refl->getMethod('extractorOptions');
+
+                    if (!$method->isStatic()) {
+                        throw new \LogicException(
+                            sprintf(
+                                'The "extractorOptions" method must be static in class "%s"',
+                                $refl->getName()
+                            )
+                        );
+                    }
+
+                    $options = call_user_func([$refl->getName(), $method->getName()], $this->container);
+                } else {
+                    $options = [];
+                }
+
+                try {
+                    $form = $this->formFactory->create($refl->getName(), null, $options);
+                } catch (ExceptionInterface $e) {
+                    $this->logError($refl, $e);
+                    $this->logger->warning(
+                        'You should add a static "extractorOptions" method to this type, and return the options.'
+                    );
+
+                    return;
+                } catch (\Exception $e) {
+                    $this->logError($refl, $e);
+
+                    return;
+                }
+
+                $labels = $this->extractView($form->createView());
+                $source = new FileSource((string) $this->file);
+
+                foreach ($labels as $label) {
+                    $this->addToCatalogue($label, $source);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param \ReflectionClass $refl
+     * @param \Exception       $e
+     */
+    protected function logError(\ReflectionClass $refl, \Exception $e)
+    {
+        $this->logger->warning(
+            sprintf(
+                'Could not extract messages from type "%s". Exception: "%s", message: "%s"',
+                $refl->getName(),
+                get_class($e),
+                $e->getMessage()
+            )
+        );
+    }
+
+    /**
+     * @param FormView $view
+     *
+     * @return array
+     */
+    protected function extractView(FormView $view)
+    {
+        $labels = [];
+
+        foreach ($view as $field) {
+            if (count($field) > 0) {
+                $labels += $this->extractView($field);
+            }
+
+            $labels[] = $field->vars['label'];
+        }
+
+        return $labels;
+    }
+
+    /**
+     * @param string          $id
+     * @param SourceInterface $source
+     * @param string          $domain
+     */
+    protected function addToCatalogue($id, SourceInterface $source, $domain = null)
+    {
+        if (null === $domain) {
+            $message = new Message($id);
+        } else {
+            $message = new Message($id, $domain);
+        }
+
+        $message->addSource($source);
+
+        $this->catalogue->add($message);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    function visitFile(\SplFileInfo $file, MessageCatalogue $catalogue)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, \Twig_Node $ast)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function leaveNode(Node $node)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function beforeTraverse(array $nodes)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function afterTraverse(array $nodes)
+    {
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,10 @@
         "symfony/form": "~2.8|~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "3.7.*",
+        "jms/translation-bundle": "~1.1",
+        "symfony/finder": "~2.8|~3.0",
+        "nikic/php-parser": "~1.4.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This is still pretty far from done, and I don't think I will finish it completely in the near future.

I will make some adjustments, write a basic test, then a merge would be great.

The idea behind this is pretty simple... instead of parsing PHP (which would not work anyway), just use the parser to find forms.
Create the form views and get the labels, dump them to the catalogue.

One major problem is the OptionsResolver, if a form has required options.

To solve that, I chose the most convinient way possible:

``` php
    /**
     * {@inheritdoc}
     */
    public function configureOptions(OptionsResolver $resolver)
    {
        $resolver
            ->setRequired('user')
            ->setAllowedTypes('user', User::class)
            ->setDefaults(
                [
                    'data_class' => Entity::class,
                ]
            )
        ;
    }

    /**
     * @param ContainerInterface $container
     *
     * @return array
     */
    public static function extractorOptions(ContainerInterface $container)
    {
        $repo = $container->get('doctrine')->getManager()->getRepository(User::class);

        return [
            'user' => $repo->findOneBy([]),
        ];
    }
```

An extractorOptions static method needs to be created, which will receive the entire container (for handling every possibility).
Keep in mind that `new User()` would not be enough when dealing with query builders for example...
