### PR TITLE
Allow to set translation domain for all forms

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -92,6 +92,10 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->scalarNode('default_translation_domain')
+                    ->info('<info>Default translation domain for all forms</info>')
+                    ->defaultValue('messages')
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/ElaoFormTranslationExtension.php
+++ b/DependencyInjection/ElaoFormTranslationExtension.php
@@ -63,6 +63,7 @@ class ElaoFormTranslationExtension extends Extension
         $container
             ->getDefinition('elao.form_translation.extension.tree_aware_extension')
             ->addMethodCall('setAutoGenerate', array($config['auto_generate']))
+            ->addMethodCall('setDefaultTranslationDomain', array($config['default_translation_domain']))
             ->addMethodCall('setTreebuilder', array(new Reference('elao.form_translation.tree_builder')))
             ->addMethodCall('setKeybuilder', array(new Reference('elao.form_translation.key_builder')));
 

--- a/Form/Extension/ChoiceTypeExtension.php
+++ b/Form/Extension/ChoiceTypeExtension.php
@@ -11,6 +11,7 @@
 namespace Elao\Bundle\FormTranslationBundle\Form\Extension;
 
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Choice Type Extension
@@ -23,5 +24,13 @@ class ChoiceTypeExtension extends TreeAwareExtension
     public function getExtendedType()
     {
         return ChoiceType::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefault('choice_translation_domain', $this->defaultTranslationDomain);
     }
 }

--- a/Form/Extension/FormTypeExtension.php
+++ b/Form/Extension/FormTypeExtension.php
@@ -34,5 +34,7 @@ class FormTypeExtension extends TreeAwareExtension
         if ($this->autoGenerate) {
             $resolver->setDefault('label', true);
         }
+        
+        $resolver->setDefault('translation_domain', $this->defaultTranslationDomain);
     }
 }

--- a/Form/Extension/TreeAwareExtension.php
+++ b/Form/Extension/TreeAwareExtension.php
@@ -50,6 +50,13 @@ abstract class TreeAwareExtension extends AbstractTypeExtension
     protected $autoGenerate = false;
 
     /**
+     * Default translation domain for all forms
+     *
+     * @var string
+     */
+    protected $defaultTranslationDomain;
+
+    /**
      * Enable or disable automatic generation of missing labels
      *
      * @param boolean $enabled The Boolean
@@ -87,6 +94,16 @@ abstract class TreeAwareExtension extends AbstractTypeExtension
     public function setKeys(array $keys)
     {
         $this->keys = $keys;
+    }
+
+    /**
+     * Set default translation domain
+     *
+     * @param string $defaultTranslationDomain
+     */
+    public function setDefaultTranslationDomain(string $defaultTranslationDomain)
+    {
+        $this->defaultTranslationDomain = $defaultTranslationDomain;
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -164,6 +164,19 @@ Which would generate that kind of keys:
     # (parent_field_name)[separator](field_name)[separator][key]
     register_name_label
 
+#### Set default translation domain for all forms
+
+You can set a default translation domain for all forms and choice with the following configuration:
+
+```yml
+elao_form_translation:
+    default_translation_domain: "forms"
+```
+
+This will set the default options `translation_domain` and `choice_translation_domain` to all forms and choices off your application.
+
+You still can override these options in each `configureOptions` method of your form types.
+
 #### Default configuration:
 
 ``` yml
@@ -174,6 +187,9 @@ elao_form_translation:
 
     # Generate translation keys for all missing labels
     auto_generate: false
+
+    # Set default translation domain on all forms
+    default_translation_domain: "messages"
 
     # Customize available keys
     keys:


### PR DESCRIPTION
```yaml
elao_form_translation:
    default_translation_domain: 'form'
```

=> Set `translation_domain` on all forms and `choice_translation_domain` on all choices.