### PR TITLE
Allow help option to be a boolean

### DIFF
--- a/Form/Extension/FormTypeExtension.php
+++ b/Form/Extension/FormTypeExtension.php
@@ -42,7 +42,10 @@ class FormTypeExtension extends TreeAwareExtension
         if ($this->autoGenerate) {
             $resolver->setDefault('label', true);
         }
-        
+
         $resolver->setDefault('translation_domain', $this->defaultTranslationDomain);
+
+        $resolver->setDefault('help', false);
+        $resolver->setAllowedTypes('help', ['null', 'string', 'boolean']);
     }
 }


### PR DESCRIPTION
As Symfony can now display help message throught the `help` option, we can use the key generator by allowing this option to be a boolean.