### PR TITLE
Set null as default translation domain

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -94,7 +94,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('default_translation_domain')
                     ->info('<info>Default translation domain for all forms</info>')
-                    ->defaultValue('messages')
+                    ->defaultNull()
                 ->end()
             ->end();
 

--- a/Form/Extension/ChoiceTypeExtension.php
+++ b/Form/Extension/ChoiceTypeExtension.php
@@ -39,6 +39,8 @@ class ChoiceTypeExtension extends TreeAwareExtension
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefault('choice_translation_domain', $this->defaultTranslationDomain);
+        if ($this->defaultTranslationDomain !== null) {
+            $resolver->setDefault('choice_translation_domain', $this->defaultTranslationDomain);
+        }
     }
 }

--- a/Form/Extension/FormTypeExtension.php
+++ b/Form/Extension/FormTypeExtension.php
@@ -43,7 +43,9 @@ class FormTypeExtension extends TreeAwareExtension
             $resolver->setDefault('label', true);
         }
 
-        $resolver->setDefault('translation_domain', $this->defaultTranslationDomain);
+        if ($this->defaultTranslationDomain !== null) {
+            $resolver->setDefault('translation_domain', $this->defaultTranslationDomain);
+        }
 
         $resolver->setDefault('help', false);
         $resolver->setAllowedTypes('help', ['null', 'string', 'boolean']);

--- a/Form/Extension/TreeAwareExtension.php
+++ b/Form/Extension/TreeAwareExtension.php
@@ -52,7 +52,7 @@ abstract class TreeAwareExtension extends AbstractTypeExtension
     /**
      * Default translation domain for all forms
      *
-     * @var string
+     * @var string|bool|null
      */
     protected $defaultTranslationDomain;
 
@@ -99,9 +99,9 @@ abstract class TreeAwareExtension extends AbstractTypeExtension
     /**
      * Set default translation domain
      *
-     * @param string $defaultTranslationDomain
+     * @param string|bool|null $defaultTranslationDomain
      */
-    public function setDefaultTranslationDomain(string $defaultTranslationDomain)
+    public function setDefaultTranslationDomain($defaultTranslationDomain)
     {
         $this->defaultTranslationDomain = $defaultTranslationDomain;
     }

--- a/README.md
+++ b/README.md
@@ -177,6 +177,13 @@ This will set the default options `translation_domain` and `choice_translation_d
 
 You still can override these options in each `configureOptions` method of your form types.
 
+You can also disable translation on all form by setting the option to `false`:
+
+```yml
+elao_form_translation:
+    default_translation_domain: false
+```
+
 #### Default configuration:
 
 ``` yml
@@ -189,7 +196,7 @@ elao_form_translation:
     auto_generate: false
 
     # Set default translation domain on all forms
-    default_translation_domain: "messages"
+    default_translation_domain: ~
 
     # Customize available keys
     keys:


### PR DESCRIPTION
* La valeur par défaut de `default_translation_domain` est désormais null
* Autorise `false` en valeur de `default_translation_domain` pour désactiver les traductions