### PR TITLE
update travis config to check php8 + last version of symfony

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,13 @@ matrix:
       env: SYMFONY_VERSION="5.0.*"
     - php: 7.4
       env: SYMFONY_VERSION="5.1.*"
+    - php: 8.0
+      env: SYMFONY_VERSION="5.2.*"
     # bleeding edge (unreleased dev versions where failures are allowed):
     - php: nightly # PHP 8
-      env: SYMFONY_VERSION="5.2.*"
+      env: SYMFONY_VERSION="5.3.*"
   allow_failures:
-    - env: SYMFONY_VERSION="5.2.*"
+    - env: SYMFONY_VERSION="5.3.*"
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0 <9.0",
+        "php": ">=7.1.0",
         "symfony/framework-bundle": "~2.8|~3.0|~4.0|~5.0",
         "symfony/form": "~2.8|~3.0|~4.0|~5.0",
         "symfony/property-access": "~2.8|~3.0|~4.0|~5.0"


### PR DESCRIPTION
I made a mistake merging the last PR, we can remove the constraint against php 9, as it will probably work fine﻿
